### PR TITLE
feat(init): add init script

### DIFF
--- a/bin/userdatamodel-init
+++ b/bin/userdatamodel-init
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import argparse
+from userdatamodel.models import * # noqa
+from userdatamodel.init_defaults import init_defaults
+from userdatamodel.driver import SQLAlchemyDriver
+
+
+def main(**kwargs):
+    db = SQLAlchemyDriver(
+        "postgresql://{username}:{password}@{host}/{db}".format(**kwargs))
+    print 'initializing database'
+    init_defaults(db)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        'userdatamodel initialization',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--username', default='postgres', help='dataabase username')
+    parser.add_argument(
+        '--password', default='', help='database password')
+    parser.add_argument(
+        '--host', default='localhost', help='database hostname')
+    parser.add_argument(
+        '--db', default='userdatamodel', help='database name')
+    args = parser.parse_args()
+    main(**args.__dict__)

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,7 @@ setup(
     install_requires=[
         'sqlalchemy==0.9.9',
     ],
+    scripts=[
+        'bin/userdatamodel-init',
+    ],
 )

--- a/userdatamodel/init_defaults.py
+++ b/userdatamodel/init_defaults.py
@@ -1,11 +1,12 @@
 from user import IdentityProvider
 IDENTITY_PROVIDERS = ['google', 'itrust']
 
+
 def init_defaults(db):
     with db.session as s:
         for provider in IDENTITY_PROVIDERS:
             if not (
                     s.query(IdentityProvider)
-                    .filter(IdentityProvider.name==provider)
+                    .filter(IdentityProvider.name == provider)
                     .first()):
                 provider = IdentityProvider(name=provider)

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -191,7 +191,7 @@ class IdentityProvider(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True)
     description = Column(String)
-    
+
     google = "google"
     itrust = "itrust"
 


### PR DESCRIPTION
r? @thanh-nguyen-dang 
```
(pi2) Yajings-MacBook-Pro:userdatamodel phillis$ userdatamodel-init -h
usage: userdatamodel initialization [-h] [--username USERNAME]
                                    [--password PASSWORD] [--host HOST]
                                    [--db DB]

optional arguments:
  -h, --help           show this help message and exit
  --username USERNAME  dataabase username (default: postgres)
  --password PASSWORD  database password (default: )
  --host HOST          database hostname (default: localhost)
  --db DB              database name (default: userdatamodel)
```